### PR TITLE
[#1] fix (operators): Add a take(1) on the duration selector of the `debounceMap` to avoid unexpected behaviors

### DIFF
--- a/packages/ng-operators/README.md
+++ b/packages/ng-operators/README.md
@@ -105,7 +105,7 @@
 
   As you can see, `fromChildEvent` takes a selector callback to get the viewChild or contentChild target.
 
-  Since the document's event can only be fired after the dom is rendered, we know that the element packageassed within the selector callback is always available.
+  Since the document's event can only be fired after the dom is rendered, we know that the element passed within the selector callback is always available.
 
 <br/>
 

--- a/packages/operators/src/lib/debounce-map.ts
+++ b/packages/operators/src/lib/debounce-map.ts
@@ -1,8 +1,13 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { ObservableInput, ObservedValueOf, OperatorFunction, from, switchMap } from 'rxjs';
+import { ObservableInput, ObservedValueOf, OperatorFunction, from, switchMap, take } from 'rxjs';
 
 export const debounceMap = <TValue, TObservableInput extends ObservableInput<any>>(
   project: (value: TValue, index: number) => TObservableInput,
   durationSelector: (value: TValue) => ObservableInput<any>
 ): OperatorFunction<TValue, ObservedValueOf<TObservableInput>> =>
-  switchMap((value, index) => from(durationSelector(value)).pipe(switchMap(() => project(value, index))));
+  switchMap((value, index) =>
+    from(durationSelector(value)).pipe(
+      take(1),
+      switchMap(() => project(value, index))
+    )
+  );


### PR DESCRIPTION
+ fix a README typo